### PR TITLE
[sc23371] [Chore] Folk the repository NFCPassportReader

### DIFF
--- a/NFCPassportReader.podspec
+++ b/NFCPassportReader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "NFCPassportReader"
-  spec.version      = "1.1.7"
+  spec.version      = "1.1.7.1"
   spec.summary      = "This package handles reading an NFC Enabled passport using iOS 13 CoreNFC APIS"
 
   spec.homepage     = "https://github.com/AndyQ/NFCPassportReader"

--- a/NFCPassportReader.podspec
+++ b/NFCPassportReader.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.platform = :ios
   spec.ios.deployment_target = "10.0"
 
-  spec.source       = { :git => "https://github.com/blyscuit/NFCPassportReader.git", :tag => "#{spec.version}" }
+  spec.source       = { :git => "https://github.com/dee-money/NFCPassportReader.git", :tag => "#{spec.version}" }
 
   spec.source_files  = "Sources/**/*.{swift}"
 

--- a/NFCPassportReader.podspec
+++ b/NFCPassportReader.podspec
@@ -8,9 +8,9 @@ Pod::Spec.new do |spec|
   spec.license      = "MIT"
   spec.author       = { "Andy Qua" => "andy.qua@gmail.com" }
   spec.platform = :ios
-  spec.ios.deployment_target = "12.0"
+  spec.ios.deployment_target = "10.0"
 
-  spec.source       = { :git => "https://github.com/AndyQ/NFCPassportReader.git", :tag => "#{spec.version}" }
+  spec.source       = { :git => "https://github.com/blyscuit/NFCPassportReader.git", :tag => "#{spec.version}" }
 
   spec.source_files  = "Sources/**/*.{swift}"
 

--- a/NFCPassportReader.podspec
+++ b/NFCPassportReader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "NFCPassportReader"
-  spec.version      = "1.1.8"
+  spec.version      = "1.1.7"
   spec.summary      = "This package handles reading an NFC Enabled passport using iOS 13 CoreNFC APIS"
 
   spec.homepage     = "https://github.com/AndyQ/NFCPassportReader"

--- a/NFCPassportReader.podspec
+++ b/NFCPassportReader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "NFCPassportReader"
-  spec.version      = "1.1.7.1"
+  spec.version      = "1.1.8"
   spec.summary      = "This package handles reading an NFC Enabled passport using iOS 13 CoreNFC APIS"
 
   spec.homepage     = "https://github.com/AndyQ/NFCPassportReader"

--- a/NFCPassportReader.podspec
+++ b/NFCPassportReader.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
 
   spec.swift_version = "5.0"
 
-  spec.dependency "OpenSSL-Universal", '1.1.180'
+  spec.dependency "OpenSSL-Universal", '1.1.1200'
   spec.xcconfig          = { 'OTHER_LDFLAGS' => '-weak_framework CryptoKit -weak_framework CoreNFC -weak_framework CryptoTokenKit' }
 
   spec.pod_target_xcconfig = {

--- a/Sources/NFCPassportReader/ChipAuthenticationHandler.swift
+++ b/Sources/NFCPassportReader/ChipAuthenticationHandler.swift
@@ -10,7 +10,10 @@ import OpenSSL
 
 #if !os(macOS)
 import CoreNFC
-import CryptoKit
+
+#if canImport(CryptoKit)
+    import CryptoKit
+#endif
 
 @available(iOS 13, *)
 class ChipAuthenticationHandler {

--- a/Sources/NFCPassportReader/PACEHandler.swift
+++ b/Sources/NFCPassportReader/PACEHandler.swift
@@ -11,7 +11,10 @@ import CryptoTokenKit
 
 #if !os(macOS)
 import CoreNFC
-import CryptoKit
+
+#if canImport(CryptoKit)
+    import CryptoKit
+#endif
 
 @available(iOS 13, *)
 private enum PACEHandlerError {

--- a/Sources/NFCPassportReader/SecureMessagingSessionKeyGenerator.swift
+++ b/Sources/NFCPassportReader/SecureMessagingSessionKeyGenerator.swift
@@ -7,7 +7,10 @@
 
 import Foundation
 
-import CryptoKit
+
+#if canImport(CryptoKit)
+    import CryptoKit
+#endif
 
 @available(iOS 13, macOS 10.15, *)
 class SecureMessagingSessionKeyGenerator {
@@ -123,34 +126,38 @@ class SecureMessagingSessionKeyGenerator {
         var hash : [UInt8]
         
         let algo = algo.lowercased()
-        if algo == "sha1" {
-            var hasher = Insecure.SHA1()
-            for d in dataElements {
-                hasher.update( data:d )
+
+        #if canImport(CryptoKit)
+            if algo == "sha1" {
+                var hasher = Insecure.SHA1()
+                for d in dataElements {
+                    hasher.update( data:d )
+                }
+                hash = Array(hasher.finalize())
+            } else if algo == "sha256" {
+                var hasher = SHA256()
+                for d in dataElements {
+                    hasher.update( data:d )
+                }
+                hash = Array(hasher.finalize())
+            } else if algo == "sha384" {
+                var hasher = SHA384()
+                for d in dataElements {
+                    hasher.update( data:d )
+                }
+                hash = Array(hasher.finalize())
+            } else if algo == "sha512" {
+                var hasher = SHA512()
+                for d in dataElements {
+                    hasher.update( data:d )
+                }
+                hash = Array(hasher.finalize())
+            } else {
+                throw NFCPassportReaderError.InvalidHashAlgorithmSpecified
             }
-            hash = Array(hasher.finalize())
-        } else if algo == "sha256" {
-            var hasher = SHA256()
-            for d in dataElements {
-                hasher.update( data:d )
-            }
-            hash = Array(hasher.finalize())
-        } else if algo == "sha384" {
-            var hasher = SHA384()
-            for d in dataElements {
-                hasher.update( data:d )
-            }
-            hash = Array(hasher.finalize())
-        } else if algo == "sha512" {
-            var hasher = SHA512()
-            for d in dataElements {
-                hasher.update( data:d )
-            }
-            hash = Array(hasher.finalize())
-        } else {
-            throw NFCPassportReaderError.InvalidHashAlgorithmSpecified
-        }
-        
+        #else
+        throw NFCPassportReaderError.NFCNotSupported
+        #endif
         return hash
     }
 }

--- a/Sources/NFCPassportReader/SecureMessagingSessionKeyGenerator.swift
+++ b/Sources/NFCPassportReader/SecureMessagingSessionKeyGenerator.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 #if canImport(CryptoKit)
     import CryptoKit
 #endif


### PR DESCRIPTION
https://github.com/dee-money/passenger-ios/pull/907
https://app.shortcut.com/deemoney/story/23371

This is a document of changes needed for this fork to compile with iOS 10 target.

## NFCPassportReader.podspec

Update `OpenSSL-Universal` to the latest version.
```
   - spec.dependency "OpenSSL-Universal", '1.1.180'
   + spec.dependency "OpenSSL-Universal", '1.1.1200'
```

Add a minor version to the pod to signify change
```
  - spec.version      = "1.1.7"
  + spec.version      = "1.1.7.1"
```

Lower required cocoapods environment from iOS 12.0 to 10.0
```
  - spec.ios.deployment_target = "12.0"
  + spec.ios.deployment_target = "10.0"
```

## .swift Source Code

Replace any import of `CryptoKit` to optional import. This fix is for Xcode 13.1 compilation error.
```
 - import CryptoKit

 + #if canImport(CryptoKit)
 +    import CryptoKit
 + #endif
```

## SecureMessagingSessionKeyGenerator.swift

Wrap `func  getHash(algo: String, dataElements:[Data] ) throws -> [UInt8] {` with iOS13 compilation flag and throw an error if CryptoKit is not presented.
```
          - if algo == "sha1" {
          - var hasher = Insecure.SHA1()
          - for d in dataElements {
          -  hasher.update( data:d )
          - }
          - hash = Array(hasher.finalize())
          - }
          - // ...
          
          + #if canImport(CryptoKit)
          + if algo == "sha1" {
          +     var hasher = Insecure.SHA1()
          +     for d in dataElements {
          +         hasher.update( data:d )
          +     }
          +     hash = Array(hasher.finalize())
          + }
          + // ...
          + #else
          + throw NFCPassportReaderError.NFCNotSupported
          + #endif